### PR TITLE
Add gitignore prettierrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+.prettierrc


### PR DESCRIPTION
안건: prettierrc.json을 gitignore에 추가

현재 문서는 CRLF로 설정되어 있습니다. 그러나 일부 개발자의 desktop에서, prettierrc가 LF로 설정하길 원하고 이로 인해 각 version이 호환되지 않는 문제가 발생중입니다. 이외에도 prettier의 기준과 호환되지 않아 발생하는 오류들이 산재해 있습니다.

이를 해결하기 위해 gitignore에 prettierrc를 추가하여 관련 오류를 없애고자 합니다.

error code 예시:
import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, UpdateDateColumn,OneToMany } from 'typeorm';

description: Replace `·Entity,·PrimaryGeneratedColumn,·Column,·ManyToOne,·CreateDateColumn,·UpdateDateColumn,OneToMany·` with `⏎··Entity,⏎··PrimaryGeneratedColumn,⏎··Column,⏎··ManyToOne,⏎··CreateDateColumn,⏎··UpdateDateColumn,⏎··OneToMany,⏎`eslint[prettier/prettier](https://github.com/prettier/eslint-plugin-prettier#options)


